### PR TITLE
Relax nokogiri dependency from 1.11.0 to 1.10.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,13 +39,11 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-      continue-on-error: ${{ matrix.unsupported }} # Only for Ruby 2.4
     - name: Run tests
       run: bundle exec rake test
       continue-on-error: ${{ matrix.unsupported }}
     - name: Run man tests
       run: bundle exec rake man
-      continue-on-error: ${{ matrix.unsupported }} # Only for Ruby 2.4
 
   rubocop:
     runs-on: ubuntu-20.04

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       kramdown (~> 2.1)
       kramdown-parser-gfm (~> 1.0.1)
       mustache (~> 1.0)
-      nokogiri (~> 1.11, >= 1.11.0)
+      nokogiri (~> 1.10, >= 1.10.10)
 
 GEM
   remote: https://rubygems.org/

--- a/nronn.gemspec
+++ b/nronn.gemspec
@@ -124,7 +124,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'kramdown',              '~> 2.1'
   s.add_dependency 'kramdown-parser-gfm',   '~> 1.0.1'
   s.add_dependency 'mustache',              '~> 1.0'
-  s.add_dependency 'nokogiri',              '~> 1.11', '>= 1.11.0'
+  s.add_dependency 'nokogiri',              '~> 1.10', '>= 1.10.10'
   s.add_development_dependency 'rack',      '~> 2.2',  '>= 2.2.3'
   s.add_development_dependency 'rake',      '~> 12.3', '>= 12.3.3'
   s.add_development_dependency 'rubocop',   '~> 0.88', '>= 0.88.0'


### PR DESCRIPTION
This is required to support Ruby 2.4.

Closes #9

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)