### PR TITLE
Workaround for psych 4.0 in tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.7', '3.0']
+        ruby-version: ['2.7', '3.0', '3.1', head]
         unsupported: [false]
         include:
           - ruby-version: '2.4'
@@ -24,10 +24,6 @@ jobs:
           - ruby-version: '2.5'
             unsupported: true
           - ruby-version: '2.6'
-            unsupported: true
-          - ruby-version: '3.1'
-            unsupported: true
-          - ruby-version: head
             unsupported: true
 
     steps:

--- a/test/test_ronn_document.rb
+++ b/test/test_ronn_document.rb
@@ -137,6 +137,11 @@ class DocumentTest < Test::Unit::TestCase
 
     test 'converting to yaml' do
       require 'yaml'
+      actual = begin
+        YAML.load(@doc.to_yaml, permitted_classes: [Time])
+      rescue ArgumentError # Remove this line when Ruby 3.0.x support is dropped
+        YAML.load(@doc.to_yaml)
+      end
       assert_equal({
                      'section'      => '1',
                      'name'         => 'hello',
@@ -146,7 +151,7 @@ class DocumentTest < Test::Unit::TestCase
                      'toc'          => [['NAME', 'NAME']],
                      'organization' => nil,
                      'manual'       => nil
-                   }, YAML.load(@doc.to_yaml))
+                   }, actual)
     end
 
     test 'converting to json' do


### PR DESCRIPTION
Closes #14

- Upstream: https://github.com/ruby/psych/pull/487

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)