### PR TITLE
Relax kramdown-parser-gfm dependency to 1.1.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     nronn (0.10.2)
       kramdown (~> 2.1)
-      kramdown-parser-gfm (~> 1.0.1)
+      kramdown-parser-gfm (>= 1.0.1, < 1.2)
       mustache (~> 1.0)
       nokogiri (~> 1.10, >= 1.10.10)
 

--- a/nronn.gemspec
+++ b/nronn.gemspec
@@ -59,7 +59,7 @@ Gem::Specification.new do |s|
 
   s.extra_rdoc_files = %w[LICENSE.txt AUTHORS]
   s.add_dependency 'kramdown',              '~> 2.1'
-  s.add_dependency 'kramdown-parser-gfm',   '~> 1.0.1'
+  s.add_dependency 'kramdown-parser-gfm',   '>= 1.0.1', '< 1.2'
   s.add_dependency 'mustache',              '~> 1.0'
   s.add_dependency 'nokogiri',              '~> 1.10', '>= 1.10.10'
   s.add_development_dependency 'rack',      '~> 2.2',  '>= 2.2.3'


### PR DESCRIPTION
- Closes #54

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)